### PR TITLE
IDN Support

### DIFF
--- a/modules/addons/ispapidomaincheck/ispapidomaincheck.php
+++ b/modules/addons/ispapidomaincheck/ispapidomaincheck.php
@@ -30,7 +30,7 @@ function ispapidomaincheck_activate()
 
     //if not existing, create ispapi_tblcategories table
     DCHelper::SQLCall(
-        "CREATE TABLE IF NOT EXISTS ispapi_tblcategories (id INT(10) NOT NULL PRIMARY KEY AUTO_INCREMENT, name TEXT, tlds TEXT)",
+        "CREATE TABLE IF NOT EXISTS ispapi_tblcategories (id INT(10) NOT NULL PRIMARY KEY AUTO_INCREMENT, name TEXT, tlds TEXT) CHARACTER SET utf8 COLLATE utf8_unicode_ci",
         null,
         "execute"
     );
@@ -40,8 +40,11 @@ function ispapidomaincheck_activate()
     if (empty($data)) {
         foreach ($categorieslib as $category => &$tlds) {
             DCHelper::SQLCall(
-                "INSERT INTO ispapi_tblcategories (name, tlds) VALUES (?, ?)",
-                array($category, implode(" ", $tlds)),
+                "INSERT INTO ispapi_tblcategories ({{KEYS}}) VALUES ({{VALUES}})",
+                array(
+                    ":name" => $category,
+                    ":tlds" => implode(" ", $tlds)
+                ),
                 "execute"
             );
         }
@@ -57,6 +60,7 @@ function ispapidomaincheck_activate()
 */
 function ispapidomaincheck_upgrade($vars)
 {
+    DCHelper::SQLCall("ALTER TABLE ispapi_tblcategories CONVERT TO CHARACTER SET utf8 COLLATE utf8_unicode_ci", null, "execute");
     if ($vars['version'] < 7.3) {
         // 1. DROP ispapi_tblaftermarketcurrencies if exists
         DCHelper::SQLCall("DROP TABLE IF EXISTS ispapi_tblaftermarketcurrencies", null, "execute");
@@ -188,7 +192,14 @@ function ispapidomaincheck_categoryeditorcontent($modulelink)
         $data = DCHelper::SQLCall("SELECT * FROM ispapi_tblcategories", null, "fetchall");
         if (empty($data)) {
             foreach ($categorieslib as $category => &$tlds) {
-                $insert_stmt = DCHelper::SQLCall("INSERT INTO ispapi_tblcategories (name, tlds) VALUES (?, ?)", array($category, implode(" ", $tlds)), "execute");
+                DCHelper::SQLCall(
+                    "INSERT INTO ispapi_tblcategories ({{KEYS}}) VALUES ({{VALUES}})",
+                    array(
+                        ":name" => $category,
+                        ":tlds" => implode(" ", $tlds)
+                    ),
+                    "execute"
+                );
             }
         } else {
             foreach ($categorieslib as $key => &$value) {
@@ -196,7 +207,14 @@ function ispapidomaincheck_categoryeditorcontent($modulelink)
             }
             if (!empty($category_not_found_in_categorieslib)) {
                 foreach ($category_not_found_in_categorieslib as $category => &$tlds) {
-                    DCHelper::SQLCall("INSERT INTO ispapi_tblcategories (name, tlds) VALUES (?, ?)", array($category, implode(" ", $tlds)), "execute");
+                    DCHelper::SQLCall(
+                        "INSERT INTO ispapi_tblcategories ({{KEYS}}) VALUES ({{VALUES}})",
+                        array(
+                            ":name" => $category,
+                            ":tlds" => implode(" ", $tlds)
+                        ),
+                        "execute"
+                    );
                 }
             }
         }
@@ -211,7 +229,14 @@ function ispapidomaincheck_categoryeditorcontent($modulelink)
         }
         //insert when added new category
         if ($_POST['NEWCAT']['NAME']) {
-            DCHelper::SQLCall("INSERT INTO ispapi_tblcategories (name, tlds) VALUES (?, ?)", array($_POST["NEWCAT"]["NAME"], $_POST["NEWCAT"]["TLDS"]), "execute");
+            DCHelper::SQLCall(
+                "INSERT INTO ispapi_tblcategories ({{KEYS}}) VALUES ({{VALUES}})",
+                array(
+                    ":name" => $_POST["NEWCAT"]["NAME"],
+                    ":tlds" => $_POST["NEWCAT"]["TLDS"]
+                ),
+                "execute"
+            );
         }
         echo '<div class="infobox"><strong><span class="title">Successfully saved!</span></strong><br>The changes have been saved.</div>';
     }

--- a/modules/addons/ispapidomaincheck/ispapidomaincheck.php
+++ b/modules/addons/ispapidomaincheck/ispapidomaincheck.php
@@ -13,11 +13,11 @@ function ispapidomaincheck_config()
 {
     global $module_version;
     return array(
-        "name" => "ISPAPI HP DomainChecker",
-        "description" => "This addon provides a new domainchecker interface with high speed checks, suggestions and premium support.",
-        "version" => $module_version,
-        "author" => "HEXONET",
-        "language" => "english",
+        "name"          => "ISPAPI HP DomainChecker",
+        "description"   => "This addon provides a new domainchecker interface with high speed checks, suggestions and premium support.",
+        "version"       => $module_version,
+        "author"        => "HEXONET",
+        "language"      => "english"
     );
 }
 
@@ -29,16 +29,27 @@ function ispapidomaincheck_activate()
     include(implode(DIRECTORY_SEPARATOR, array(dirname(__FILE__),"categories.php")));
 
     //if not existing, create ispapi_tblcategories table
-    DCHelper::SQLCall("CREATE TABLE IF NOT EXISTS ispapi_tblcategories (id INT(10) NOT NULL PRIMARY KEY AUTO_INCREMENT, name TEXT, tlds TEXT)", array(), "execute");
+    DCHelper::SQLCall(
+        "CREATE TABLE IF NOT EXISTS ispapi_tblcategories (id INT(10) NOT NULL PRIMARY KEY AUTO_INCREMENT, name TEXT, tlds TEXT)",
+        null,
+        "execute"
+    );
 
     //import the default categories when empty
-    $data = DCHelper::SQLCall("SELECT * FROM ispapi_tblcategories", array(), "fetchall");
+    $data = DCHelper::SQLCall("SELECT * FROM ispapi_tblcategories", null, "fetchall");
     if (empty($data)) {
         foreach ($categorieslib as $category => &$tlds) {
-            DCHelper::SQLCall("INSERT INTO ispapi_tblcategories (name, tlds) VALUES (?, ?)", array($category, implode(" ", $tlds)), "execute");
+            DCHelper::SQLCall(
+                "INSERT INTO ispapi_tblcategories (name, tlds) VALUES (?, ?)",
+                array($category, implode(" ", $tlds)),
+                "execute"
+            );
         }
     }
-    return array('status'=>'success', 'description'=>'The ISPAPI HP DomainChecker was successfully installed.');
+    return array(
+        'status'        =>  'success',
+        'description'   =>  'The ISPAPI HP DomainChecker was successfully installed.'
+    );
 }
 
 /*
@@ -48,15 +59,18 @@ function ispapidomaincheck_upgrade($vars)
 {
     if ($vars['version'] < 7.3) {
         // 1. DROP ispapi_tblaftermarketcurrencies if exists
-        DCHelper::SQLCall("DROP TABLE IF EXISTS ispapi_tblaftermarketcurrencies", array(), "execute");
+        DCHelper::SQLCall("DROP TABLE IF EXISTS ispapi_tblaftermarketcurrencies", null, "execute");
         // 2. DROP ispapi_tblsettings if exists
-        DCHelper::SQLCall("DROP TABLE IF EXISTS ispapi_tblsettings", array(), "execute");
+        DCHelper::SQLCall("DROP TABLE IF EXISTS ispapi_tblsettings", null, "execute");
         // 3. ALTER ispapi_tblcategories
-        DCHelper::SQLCall("ALTER TABLE ispapi_tblcategories DROP COLUMN parent", array(), "execute");
+        DCHelper::SQLCall("ALTER TABLE ispapi_tblcategories DROP COLUMN parent", null, "execute");
         // This one deletes the row and does not complain if it can't.
-        DCHelper::SQLCall("DELETE IGNORE FROM ispapi_tblcategories WHERE tlds=''", array(), "execute");
+        DCHelper::SQLCall("DELETE IGNORE FROM ispapi_tblcategories WHERE tlds=''", null, "execute");
     }
-    return array('status'=>'success', 'description'=>'The ISPAPI HP DomainChecker was successfully upgraded.');
+    return array(
+        'status'        =>  'success',
+        'description'   =>  'The ISPAPI HP DomainChecker was successfully upgraded.'
+    );
 }
 
 /*
@@ -65,7 +79,10 @@ function ispapidomaincheck_upgrade($vars)
 function ispapidomaincheck_deactivate()
 {
     //NOTHING TO DO
-    return array('status'=>'success','description'=>'The ISPAPI HP DomainChecker was successfully uninstalled.');
+    return array(
+        'status'        =>  'success',
+        'description'   =>  'The ISPAPI HP DomainChecker was successfully uninstalled.'
+    );
 }
 
 /*
@@ -77,7 +94,7 @@ function ispapidomaincheck_clientarea($vars)
 {
     //save the language in the session if not already set
     if (!isset($_SESSION["Language"])) {
-        $language_array = DCHelper::SQLCall("SELECT value FROM tblconfiguration WHERE setting='Language'", array(), "fetch");
+        $language_array = DCHelper::SQLCall("SELECT value FROM tblconfiguration WHERE setting='Language'", null, "fetch");
         $_SESSION["Language"] = strtolower($language_array["value"]);
     }
 
@@ -87,7 +104,7 @@ function ispapidomaincheck_clientarea($vars)
             'templatefile' => 'ispapidomaincheck',
             'requirelogin' => false,
             'vars' => array(
-                    'categories' => DCHelper::SQLCall("SELECT * FROM ispapi_tblcategories", array(), "fetchall"),
+                    'categories' => DCHelper::SQLCall("SELECT * FROM ispapi_tblcategories", null, "fetchall"),
                     'startsequence' => 4,
                     'modulename' => "ispapidomaincheck",
                     'modulepath' => "modules/addons/ispapidomaincheck/",
@@ -96,7 +113,7 @@ function ispapidomaincheck_clientarea($vars)
                     'path_to_domain_file' => "modules/addons/ispapidomaincheck/domain.php",
                     'domain' => isset($_POST["domain"]) ? $_POST["domain"] : "",
                     'currency' => $_SESSION["currency"]
-            ),
+            )
     );
 }
 
@@ -168,7 +185,7 @@ function ispapidomaincheck_categoryeditorcontent($modulelink)
     //import default categories
     if (isset($_REQUEST["importdefaultcategories"])) {
         $category_not_found_in_categorieslib = array();
-        $data = DCHelper::SQLCall("SELECT * FROM ispapi_tblcategories", array(), "fetchall");
+        $data = DCHelper::SQLCall("SELECT * FROM ispapi_tblcategories", null, "fetchall");
         if (empty($data)) {
             foreach ($categorieslib as $category => &$tlds) {
                 $insert_stmt = DCHelper::SQLCall("INSERT INTO ispapi_tblcategories (name, tlds) VALUES (?, ?)", array($category, implode(" ", $tlds)), "execute");
@@ -209,7 +226,7 @@ function ispapidomaincheck_categoryeditorcontent($modulelink)
     ###############################################################################
 
     //get all categories with tlds for displaying
-    $categories = DCHelper::SQLCall("SELECT * FROM ispapi_tblcategories", array(), "fetchall");
+    $categories = DCHelper::SQLCall("SELECT * FROM ispapi_tblcategories", null, "fetchall");
 
     echo '<form action="'.$modulelink.'" method="post">';
     echo '<div class="tablebg" align="center"><table id="domainpricing" class="datatable" cellspacing="1" cellpadding="3" border="0" width="100%"><tbody>';

--- a/modules/addons/ispapidomaincheck/ispapidomaincheck.tpl
+++ b/modules/addons/ispapidomaincheck/ispapidomaincheck.tpl
@@ -441,9 +441,9 @@ $( document ).ready(function() {
                 handleFeedbackMessage(data);
 
                 //handle load more button
-                checkorder_length = data["checkorder"].length;
+                checkorder_length = data["idn"].length;
                 //display load more button if the list of domain is more than 10
-                if(data["checkorder"].length > 10){
+                if(data["idn"].length > 10){
                     $("#domainform input[id=loadmorebutton]").removeClass('hide');
                 }
 
@@ -451,7 +451,7 @@ $( document ).ready(function() {
                 //to hide divs with class when max limit exeeded
                 var hide = '';
 
-				$.each(data["checkorder"], function(index, element) {
+				$.each(data["idn"], function(index, element) {
 
 					var domain = element; //.replace(/\./g, '');
                     var index = domain.indexOf(".");
@@ -498,7 +498,7 @@ $( document ).ready(function() {
 					checkdomains(new Array(), true);
 					return;
 				}else{
-                    startChecking(data["checkorder"]);
+                    startChecking(data["idn"]);
 				}
 			}
 		});

--- a/modules/addons/ispapidomaincheck/lib/DCHelper.class.php
+++ b/modules/addons/ispapidomaincheck/lib/DCHelper.class.php
@@ -7,6 +7,7 @@ if (file_exists($path)) {
 } else {
     die('Please install our <a href="https://github.com/hexonet/whmcs-ispapi-registrar/raw/master/whmcs-ispapi-registrar-latest.zip">ISPAPI Registrar Module</a> >= v1.7.1');
 }
+require_once(implode(DIRECTORY_SEPARATOR, array(__DIR__,"i18n.class.php")));
 
 /**
  * PHP DCHelper Class


### PR DESCRIPTION
**Still open for review in next days**:
* ispapi_tblcategories needs to be set to support utf8 strings and realize upgrade procedure in module upgrade and correct table create procedure in module activation method
* maybe it is even easier to go the way of separating the TLDs from category table
* check if ConvertIDN works for DOMAIN# index higher than 255, if not review this
* when searching for punycode domain, we return it now in idn form, that could be the reason that the big block for adding it to cart is no longer coming up, but still it is possible to add it

@anthonyschn fyi, if you want and if you have time, have an eye on the changes that got already applied.